### PR TITLE
Kosmetyka – wielkość liter w nagłówkach

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# STATUT STOWARZYSZENIA HAKIERSPEJS ŁÓDŹ
+# Statut stowarzyszenia Hakierspejs Łódź
 
-## ROZDZIAŁ I - POSTANOWIENIA OGÓLNE
+## Rozdział I – Postanowienia ogólne
 
 Stowarzyszenie nosi nazwę “Hakierspejs Łódź”, w skrócie “HSŁ”, w języku angielskim “Hackerspace Łódź”, w dalszych postanowieniach zwane Stowarzyszeniem.
 
@@ -18,7 +18,7 @@ Członkami Stowarzyszenia mogą być cudzoziemcy, włącznie z osobami nie mają
 
 
 
-## ROZDZIAŁ II - CELE I ŚRODKI DZIAŁANIA
+## Rozdział II – Cele i środki działania
 
 
 
@@ -46,7 +46,7 @@ i) współpracę z krajowymi i zagranicznymi organizacjami.
 
 
 
-### ROZDZIAŁ III - CZŁONKOWIE – PRAWA I OBOWIĄZKI
+### Rozdział III – Członkowie – prawa i obowiązki
 
 
 
@@ -116,7 +116,7 @@ Od uchwały Zarządu w sprawie pozbawienia członkostwa zainteresowanemu przysł
 
 
 
-## ROZDZIAŁ IV - WŁADZE STOWARZYSZENIA
+## Rozdział IV – Władze stowarzyszenia
 
 
 
@@ -228,7 +228,7 @@ W razie gdy skład władz Stowarzyszenia ulegnie zmniejszeniu w czasie trwania k
 
 
 
-## ROZDZIAŁ V - MAJĄTEK I FUNDUSZE
+## Rozdział V – Majątek i fundusze
 
 
 
@@ -266,7 +266,7 @@ b) upoważniony jest każdy członek zarządu działający samodzielnie, jeżeli
 
 
 
-## ROZDZIAŁ VI - POSTANOWIENIA KOŃCOWE
+## Rozdział VI – Postanowienia końcowe
 
 
 


### PR DESCRIPTION
Wielkie litery w nagłówkach są redundantne względem samego oznaczania ich jako nagłówki... Moim zdaniem – kłóci się to z dobrymi praktykami formatowania dokumentów, także (a może i szczególnie) tych elektronicznych; to, w jaki sposób wyświetlane i formatowane są nagłówki (rozmiar czcionki, pogrubienie, podkreślenie, także właśnie wielkość liter w sensie małe/wielkie) powinno zależeć od stylu określonego dla elementu "nagłówek" a nie być zahardcode'owane

Poprawiłem to już w pierwotnym tekście statutu, tym, który był na Padzie, ale ktoś to z jakiegoś powodu zmienił z powrotem na wielkie litery... Ja się z tym nie zgadzam.