### PR TITLE
Walne Zgromadzenie -> Walne Zebranie

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ c) utraty praw publicznych na mocy prawomocnego wyroku sądu,
 
 d) śmierci członka oraz utraty osobowości prawnej przez osoby prawne.
 
-Od uchwały Zarządu w sprawie pozbawienia członkostwa zainteresowanemu przysługuje odwołanie do Walnego Zgromadzenia Członków. Odwołanie powinno zostać przekazane Zarządowi w formie pisemnej w terminie 14 dni od chwili poinformowania zainteresowanego o treści uchwały Zarządu. Uchwała Walnego Zgromadzenia Członków jest ostateczna i wchodzi w życie w trybie natychmiastowym.
+Od uchwały Zarządu w sprawie pozbawienia członkostwa zainteresowanemu przysługuje odwołanie do Walnego Zebrania Członków. Odwołanie powinno zostać przekazane Zarządowi w formie pisemnej w terminie 14 dni od chwili poinformowania zainteresowanego o treści uchwały Zarządu. Uchwała Walnego Zebrania Członków jest ostateczna i wchodzi w życie w trybie natychmiastowym.
 
 
 
@@ -122,7 +122,7 @@ Od uchwały Zarządu w sprawie pozbawienia członkostwa zainteresowanemu przysł
 
 Władzami Stowarzyszenia są:
 
-a) Walne Zgromadzenie Członków,
+a) Walne Zebranie Członków,
 
 b) Zarząd,
 
@@ -132,27 +132,27 @@ Kadencja wszystkich władz wybieralnych Stowarzyszenia trwa dwa lata,
 
 Uchwały wszystkich władz Stowarzyszenia zapadają zwykłą większością głosów przy obecności co najmniej połowy członków uprawnionych do głosowania, stanowiących kworum, chyba że dalsze postanowienia statutu stanowią inaczej.
 
-Walne Zgromadzenie Członków jest najwyższą władzą Stowarzyszenia. W Walnym Zgromadzeniu Członków biorą udział:
+Walne Zebranie Członków jest najwyższą władzą Stowarzyszenia. W Walnym Zebraniu Członków biorą udział:
 
 a) z głosem stanowiącym – członkowie zwyczajni,
 
 b) z głosem doradczym – członkowie wspierający oraz zaproszeni goście.
 
-Walne Zgromadzenie Członków może być zwyczajne i nadzwyczajne.
+Walne Zebranie Członków może być zwyczajne i nadzwyczajne.
 
-Dla zwołania Walnego Zgromadzenia Członków podaje się dwa terminy. Jeśli w pierwszym terminie nie zbierze się kworum Walne Zgromadzenie Członków odbywa się w drugim terminie.
+Dla zwołania Walnego Zebrania Członków podaje się dwa terminy. Jeśli w pierwszym terminie nie zbierze się kworum Walne Zebranie Członków odbywa się w drugim terminie.
 
-Aby Walne Zgromadzenie Członków mogło się rozpocząć w pierwszym terminie wymagane jest kworum, czyli obecność conajmniej połowy ogólnej liczby zwyczajnych członków Stowarzyszenia. W drugim terminie kworum nie jest wymagane.
+Aby Walne Zebranie Członków mogło się rozpocząć w pierwszym terminie wymagane jest kworum, czyli obecność conajmniej połowy ogólnej liczby zwyczajnych członków Stowarzyszenia. W drugim terminie kworum nie jest wymagane.
 
-Oba terminy Walnego Zgromadzenia Członków nie mogą być odległe bardziej niż 14 dni kalendarzowych.
+Oba terminy Walnego Zebrania Członków nie mogą być odległe bardziej niż 14 dni kalendarzowych.
 
-Walne Zgromadzenie Członków zwyczajne jest zwoływane nie rzadziej niż raz na dwa lata przez Zarząd Stowarzyszenia w siedzibie stowarzyszenia. Termin obrad Zarząd podaje do wiadomości wszystkich członków co najmniej 14 dni przed pierwszym terminem zebrania.
+Walne Zebranie Członków zwyczajne jest zwoływane nie rzadziej niż raz na dwa lata przez Zarząd Stowarzyszenia w siedzibie stowarzyszenia. Termin obrad Zarząd podaje do wiadomości wszystkich członków co najmniej 14 dni przed pierwszym terminem zebrania.
 
-Walne Zgromadzenie Członków nadzwyczajne może się odbyć w każdym czasie w siedzibie stowarzyszenia. Jest zwoływane przez Zarząd z jego inicjatywy, na wniosek Komisji Rewizyjnej lub pisemny wniosek co najmniej 1/3 ogólnej liczby członków zwyczajnych Stowarzyszenia. Pierwszy termin Walnego Zgromadzenia Członków nadzwyczajnego powinien być określony na niepoźniejszy niż 30 dni kalendarzowych od daty wpływu wniosku do Zarządu. Wniosek powinien zawierać propozycje terminów oraz porządku obrad. Nadzwyczajne Walne Zgromadzenie obraduje nad sprawami, dla których zostało zwołane.
+Walne Zebranie Członków nadzwyczajne może się odbyć w każdym czasie w siedzibie stowarzyszenia. Jest zwoływane przez Zarząd z jego inicjatywy, na wniosek Komisji Rewizyjnej lub pisemny wniosek co najmniej 1/3 ogólnej liczby członków zwyczajnych Stowarzyszenia. Pierwszy termin Walnego Zebrania Członków nadzwyczajnego powinien być określony na niepoźniejszy niż 30 dni kalendarzowych od daty wpływu wniosku do Zarządu. Wniosek powinien zawierać propozycje terminów oraz porządku obrad. Nadzwyczajne Walne Zebranie obraduje nad sprawami, dla których zostało zwołane.
 
-Uchwały Walnego Zgromadzenia Członków zapadają zwykłą większością głosów w trybie głosowania jawnego lub, na żądanie dowolnego uczestnika, tajnego.
+Uchwały Walnego Zebrania Członków zapadają zwykłą większością głosów w trybie głosowania jawnego lub, na żądanie dowolnego uczestnika, tajnego.
 
-Do kompetencji Walnego Zgromadzenia Członków należą:
+Do kompetencji Walnego Zebrania Członków należą:
 
 a) określenie głównych kierunków działania i rozwoju Stowarzyszenia,
 
@@ -176,7 +176,7 @@ j) podejmowanie uchwał w każdej sprawie wniesionej pod obrady, we wszystkich s
 
 Uchwały o wyborze i odwoływaniu władz stowarzyszenia oraz zmianach statutu wymagają bezwzględnej większości głosów.
 
-Zarząd jest powołany do kierowania całą działalnością Stowarzyszenia zgodnie z uchwałami Walnego Zgromadzenia Członków, a także reprezentuje Stowarzyszenie wobec organów administracji i sądów.
+Zarząd jest powołany do kierowania całą działalnością Stowarzyszenia zgodnie z uchwałami Walnego Zebrania Członków, a także reprezentuje Stowarzyszenie wobec organów administracji i sądów.
 
 Zarząd składa się z 3 do 7 osób w tym prezesa, skarbnika i sekretarza.
 
@@ -188,7 +188,7 @@ Do kompetencji Zarządu należą:
 
 a) realizacja celów Stowarzyszenia,
 
-b) wykonywanie uchwał Walnego Zgromadzenia Członków,
+b) wykonywanie uchwał Walnego Zebrania Członków,
 
 c) sporządzanie planów pracy i budżetu,
 
@@ -198,11 +198,11 @@ e) podejmowanie uchwał o zarządzaniu majątkiem Stowarzyszenia,
 
 f) reprezentowanie Stowarzyszenia wobec organów administracji i sądów,
 
-g) zwoływanie Walnego Zgromadzenia Członków,
+g) zwoływanie Walnego Zebrania Członków,
 
 h) przyjmowanie i skreślanie członków,
 
-i) składanie sprawozdań ze swojej działalności na Walnym Zgromadzeniu Członków,
+i) składanie sprawozdań ze swojej działalności na Walnym Zebraniu Członków,
 
 j) sporządzanie rocznego sprawozdania finansowego.
 
@@ -214,13 +214,13 @@ Do kompetencji Komisji Rewizyjnej należy:
 
 a) kontrolowanie działalności Zarządu,
 
-b) składanie wniosków z kontroli na Walnym Zgromadzeniu Członków,
+b) składanie wniosków z kontroli na Walnym Zebraniu Członków,
 
-c) prawo wystąpienia z wnioskiem o zwołanie Walnego Zgromadzenia Członków oraz zebrania Zarządu,
+c) prawo wystąpienia z wnioskiem o zwołanie Walnego Zebrania Członków oraz zebrania Zarządu,
 
 d) składanie wniosków o absolutorium dla Zarządu Stowarzyszenia,
 
-e) składanie sprawozdań ze swojej działalności na Walnym Zgromadzeniu Członków,
+e) składanie sprawozdań ze swojej działalności na Walnym Zebraniu Członków,
 
 f) zatwierdzanie rocznego sprawozdania finansowego.
 
@@ -260,7 +260,7 @@ Zarząd zobowiązany jest dołożyć wszelkich starań w celu utrzymania zapasu 
 
 Do zawierania umów, udzielania pełnomocnictwa i składania innych oświadczeń woli, w szczególności w sprawach majątkowych:
 
-a) upoważnionych jest dowolnych dwóch członków Zarządu działających łącznie
+a) upoważnionych jest dowolnych dwóch członków Zarządu działających łącznie,
 
 b) upoważniony jest każdy członek zarządu działający samodzielnie, jeżeli wysokość podejmowanego zobowiązania nie przekracza 128 PLN jednorazowo lub 512 PLN łącznie w czasie trwania jednego miesiąca.
 
@@ -270,9 +270,9 @@ b) upoważniony jest każdy członek zarządu działający samodzielnie, jeżeli
 
 
 
-Uchwałę w sprawie zmiany Statutu oraz uchwałę o rozwiązaniu Stowarzyszenia podejmuje Walne Zgromadzenie Członków kwalifikowaną większością głosów (2/3), przy obecności co najmniej połowy łącznej liczby członków Stowarzyszenia uprawnionych do głosowania, stanowiących kworum.
+Uchwałę w sprawie zmiany Statutu oraz uchwałę o rozwiązaniu Stowarzyszenia podejmuje Walne Zebranie Członków kwalifikowaną większością głosów (2/3), przy obecności co najmniej połowy łącznej liczby członków Stowarzyszenia uprawnionych do głosowania, stanowiących kworum.
 
-Podejmując uchwałę o rozwiązaniu Stowarzyszenia Walne Zgromadzenie Członków określa sposób jego likwidacji oraz przeznaczenie majątku Stowarzyszenia.
+Podejmując uchwałę o rozwiązaniu Stowarzyszenia Walne Zebranie Członków określa sposób jego likwidacji oraz przeznaczenie majątku Stowarzyszenia.
 
 W sprawach nie uregulowanych w niniejszym statucie zastosowanie mają przepisy ustawy Prawo o Stowarzyszeniach.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Walne Zebranie Członków może być zwyczajne i nadzwyczajne.
 
 Dla zwołania Walnego Zebrania Członków podaje się dwa terminy. Jeśli w pierwszym terminie nie zbierze się kworum, Walne Zebranie Członków odbywa się w drugim terminie.
 
-Aby Walne Zebrania Członków mogło się rozpocząć w pierwszym terminie, wymagane jest kworum, czyli obecność co najmniej połowy ogólnej liczby zwyczajnych członków Stowarzyszenia. W drugim terminie kworum nie jest wymagane.
+Aby Walne Zebranie Członków mogło się rozpocząć w pierwszym terminie, wymagane jest kworum, czyli obecność co najmniej połowy ogólnej liczby zwyczajnych członków Stowarzyszenia. W drugim terminie kworum nie jest wymagane.
 
 Oba terminy Walnego Zebrania Członków nie mogą być odległe bardziej niż 14 dni kalendarzowych.
 


### PR DESCRIPTION
Ustawa Prawo o stowarzyszeniach posługuje się pojęciem "walne zebranie członków", a nie "walne zgromadzenie członków"
Z tego, co piszą na ngo.pl – rzadko, ale zdarza się, że sądy kwestionują "walne zgromadzenie" w statucie – wydaje mi się, że warto to zmienić, bo w ten sposób możemy sobie zaoszczędzić zwrotu statutu przez sąd do poprawki