### PR TITLE
Minimalny interwał terminów walnego zwyczajnego

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Aby Walne Zebranie Członków mogło się rozpocząć w pierwszym terminie, wyma
 
 Oba terminy Walnego Zebrania Członków nie mogą być odległe bardziej niż 14 dni kalendarzowych.
 
-Walne Zebranie Członków zwyczajne jest zwoływane nie rzadziej niż raz na dwa lata przez Zarząd Stowarzyszenia w siedzibie Stowarzyszenia. Termin obrad Zarząd podaje do wiadomości wszystkich członków co najmniej 14 dni przed pierwszym terminem zebrania.
+Walne Zebranie Członków zwyczajne jest zwoływane nie rzadziej niż raz na dwa lata przez Zarząd Stowarzyszenia w siedzibie Stowarzyszenia. Termin obrad Zarząd podaje do wiadomości wszystkich członków co najmniej 14 dni przed pierwszym terminem zebrania. Oba terminy zebrania muszą być oddalone o co najmniej <x> dni robocze/-ych/kalendarzowe/-ych.
 
 Walne Zebranie Członków nadzwyczajne może się odbyć w każdym czasie w siedzibie stowarzyszenia. 
 


### PR DESCRIPTION
Podczas dyskusji wiele razy padła sugestia, że prawdopodobnie nie powinno być możliwości ustalenia drugiego terminu zwyczajnego walnego zebrania członków (tego bez kworum) na 2 godziny po pierwszym (z kworum), tak jak to typowo robi HS-Waw. Bo w ten sposób istnienie dwóch terminów w ogóle nie ma sensu, równie dobrze można przyjąć, że w pierwszym terminie nie jest wymagane kworum. Poza tym chyba kłóci się to trochę z zasadami demokracji, chociaż z tym można dyskutować (walne zwyczajne i tak musi być zapowiedziane z dużym wyprzedzeniem). Z drugiej strony, jeśli HS-Łódź się rozrośnie, może być tak, że nigdy nie uda nam się zebrać kworum, ale to prawdopodobnie będzie dobry moment, by zmienić statut.

Okazuje się, że tego nie ma w statucie i dotąd nikt nie zrobił na to PR-a...

Nie sugeruję konkretnej liczby dni, bo nie jestem przekonany, czy powinny to być np. 2 dni, jak przy nadzwyczajnym, czy może 7 dni, lub nawet dwa tygodnie (przy zwyczajnym z założenia nie goni nas czas, więc dlaczego nie?). Zamiast tego robię w tej kwestii ankietę na forum.

Tak więc robię.