### PR TITLE
Sposób zawiadamiania członków o walnym

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ b) Zarząd,
 
 c) Komisja Rewizyjna.
 
-Kadencja wszystkich władz wybieralnych Stowarzyszenia trwa dwa lata,
+Kadencja wszystkich władz wybieralnych Stowarzyszenia trwa dwa lata.
 
 Uchwały wszystkich władz Stowarzyszenia zapadają zwykłą większością głosów przy obecności co najmniej połowy członków uprawnionych do głosowania, stanowiących kworum, chyba że dalsze postanowienia statutu stanowią inaczej.
 
@@ -140,7 +140,7 @@ b) z głosem doradczym – członkowie wspierający oraz zaproszeni goście.
 
 Walne Zebranie Członków może być zwyczajne i nadzwyczajne.
 
-Dla zwołania Walnego Zebrania Członków podaje się dwa terminy. Jeśli w pierwszym terminie nie zbierze się kworum, Walne Zebranie Członków odbywa się w drugim terminie.
+Dla zwołania Walnego Zebrania Członków podaje się dwa terminy. Jeśli w pierwszym terminie nie zbierze się kworum, Walne Zebranie Członków odbywa się w drugim terminie. Członków Stowarzyszenia zawiadamia się o terminach Walnego Zebrania za pośrednictwem poczty elektronicznej.
 
 Aby Walne Zebranie Członków mogło się rozpocząć w pierwszym terminie, wymagane jest kworum, czyli obecność co najmniej połowy ogólnej liczby zwyczajnych członków Stowarzyszenia. W drugim terminie kworum nie jest wymagane.
 


### PR DESCRIPTION
Ngo.pl mówi, że w statucie powinno zawrzeć się informację o sposobie powiadamiania o terminach walnych zebrań: https://poradnik.ngo.pl/walne-zebranie-czlonkow-stowarzyszenia

Co prawda ja nie kojarzę, by zapis, który by to nakazywał, znajdował się w ustawie, ale chyba mimo wszystko warto, by to było uwzględnione w statucie, chociażby po to, by nie było potem kłótni typu "nie wiedziałem, że było walne".

Dwa polskie HS-y: Wrocław i Pomorze mają to określone w statutach.

Dlaczego mail?

Sam początkowo chciałem tu wpisać "drogą elektroniczną", ewentualnie "za pomocą co najmniej dwóch różnych kanałów komunikacji (np. poczta elektroniczna i komunikator internetowy)".

Ale:
1) raczej powinno to być możliwie precyzyjnie określone, żeby nie było potem sytuacji, że np. powiadomi się kogoś przez jakiś komunikator, na który wcale nie wchodzi,
2) bardzo wskazane jest, by dało się potem udowodnić, że powiadomienie o terminie walnego zostało wysłane. Jak z tym jest w przypadku maili – można dyskutować, np. to, że wiadomość została zapisana w folderze "wysłane", to raczej nie jest żaden dowód – ale wystarczy wpisać maile wszystkich członków jako odbiorców wiadomości (byle nie w trybie BCC, z punktu widzenia ochrony danych chyba nie jest to problem, możemy przyjąć, że z założenia będziemy znać nawzajem swoje maile; to, kurczę, członkowie stowarzyszenia, a nie klienci jakiejś firmy, którzy nie mają ze sobą nic wspólnego), by mógł to potwierdzić jakikolwiek inny członek; równocześnie w interesie członka będzie wtedy, by zarząd dysponował jego aktualnym adresem mailowym i by nie miał skrzynki skonfigurowanej tak, że maile od HS-u wpadają do spamu,
3) komunikatory, jakie są na topie, ciągle się zmieniają, a maile funkcjonują w Internecie chyba od zawsze i pewnie nie znikną jako w miarę powszechny sposób komunikacji przez Internet nigdy, co najwyżej zmieniać się będą protokoły używane do ich przesyłania,
4) raczej każdy sprawdza w miarę na bieżąco skrzynkę mailową, lub wręcz ma skonfigurowane powiadomienia live o otrzymywanych mailach,
5) wspomniane dwa HS-y mają właśnie maile jako sposób powiadamiania,
6) jeśli dwa kanały komunikacji, to co oprócz maila? przypięty post np. na Telegramie nie załatwia sprawy, bo nie da się zweryfikować, czy ktoś go przeczytał, czy nie. A nie wpiszemy do statutu "w formie przypiętego postu na Telegramie", bo kiedyś z jakiegoś powodu zejdziemy z Telegrama i trzeba będzie zmienić statut.