### PR TITLE
Przeniesienie maksymalnych kwot samodzielnie podejmowanego zobowiązan…

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Do zawierania umów, udzielania pełnomocnictwa i składania innych oświadczeń
 
 a) upoważnionych jest dowolnych dwóch członków Zarządu działających łącznie,
 
-b) upoważniony jest każdy członek zarządu działający samodzielnie, jeżeli wysokość podejmowanego zobowiązania nie przekracza 128 PLN jednorazowo lub 512 PLN łącznie w czasie trwania jednego miesiąca.
+b) upoważniony jest każdy członek Zarządu działający samodzielnie, jeżeli wysokość podejmowanego zobowiązania oraz suma łącznej wysokości zobowiązań podjętych w przeciągu ostatnich 30 dni nie przekroczą kwot określonych przez Zarząd na drodze uchwały.
 
 
 


### PR DESCRIPTION
…ia do uchwał

Wiem, że takie okrągłe binarnie kwoty wyglądają fajnie, ale statut z wpisanymi na sztywno kwotami jest nieodporny na inflację.
Wpisałem, zgodnie z sugestią olewalesa z issue: https://github.com/hakierspejs/statut/issues/27, że kwoty są określane na drodze uchwał przez zarząd. Nie wiem, czy nie powinno to leżeć w kompetencjach walnego, ale chyba zarząd jest okej, bo on i tak ponosi odpowiedzialność za finanse, a pozostawienie tego do decyzji walnego może oznaczać, że w razie hiperinflacji, tylko z jej powodu, trzeba będzie zwołać nadzwyczajne walne, by zmienić te kwoty.